### PR TITLE
Use different conan generators.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,14 @@ endif ()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Add conan files.
-if (EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-    conan_basic_setup()
+if (EXISTS ${CMAKE_BINARY_DIR}/conan_paths.cmake)
+    include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
+endif ()
+
+# Find external libraries.
+find_package(fmt)
+if (NOT TARGET fmt::fmt)
+    message(FATAL_ERROR "fmt not found")
 endif ()
 
 # Project-wide compilation options.

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -2,4 +2,5 @@
 fmt/6.0.0@bincrafters/stable
 
 [generators]
-cmake
+cmake_find_package
+cmake_paths

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -6,5 +6,5 @@ add_library(appplatform-demo EXCLUDE_FROM_ALL
 
 target_link_libraries(appplatform-demo
     PUBLIC platform-init
-    PRIVATE $<IF:$<CONFIG:Debug>,fmtd,fmt>
+    PRIVATE fmt::fmt
 )


### PR DESCRIPTION
### Brief overview of the proposed changes.
Use cmake_paths and cmake_find_package generators instead of cmake in conan.
This allow usage of find_package and link with target `fmt::fmt` instead of conditional for debug/realease.

### Related issues

None.
